### PR TITLE
Build heuristic GenAI product insights pipeline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+__pycache__/
+*.pyc
+.venv/
+build/

--- a/DataPiplineForProductManagerUsingGenAI
+++ b/DataPiplineForProductManagerUsingGenAI
@@ -1,1 +1,0 @@
-testfile

--- a/README.md
+++ b/README.md
@@ -1,0 +1,89 @@
+# Data Pipeline for Product Managers Using GenAI
+
+This repository provides a lightweight product insights pipeline inspired by the
+prompt described in [DataPiplineForProductManagerUsingGenAI](https://github.com/akkhil2012/DataPiplineForProductManagerUsingGenAI).
+
+The goal of the application is to help product managers transform raw customer
+feedback into structured, actionable artifacts using a GenAI-inspired approach.
+Since access to remote LLM services is unavailable in this execution
+environment, the project ships with a transparent heuristic generator that
+emulates GenAI behaviour. The pipeline is modular, so it can be replaced with a
+real LLM-backed implementation when desired.
+
+## Features
+
+- **Data ingestion**: Load customer feedback from CSV files into strongly typed
+  data classes.
+- **Pre-processing**: Cleanse and normalise feedback text, remove noise, and
+  detect duplicates.
+- **Theme detection**: Classify feedback into strategic product themes with
+  configurable keyword dictionaries.
+- **Impact scoring**: Combine qualitative impact assessments with occurrence
+  frequency to surface high priority opportunities.
+- **Insight generation**: Produce product briefs, customer journey summaries,
+  and roadmap recommendations using templated reasoning similar to GenAI
+  outputs.
+- **CLI utility**: Run the complete pipeline and export summaries as Markdown
+  files ready for inclusion in product review documents.
+
+## Project Structure
+
+```
+.
+├── data
+│   └── sample_feedback.csv      # Example dataset used by the tests and demo
+├── src
+│   └── pm_pipeline
+│       ├── __init__.py
+│       ├── analysis.py          # Theme extraction & scoring logic
+│       ├── cli.py               # Command line interface entrypoint
+│       ├── data_loader.py       # CSV ingestion helpers
+│       ├── insight_generator.py # Heuristic "GenAI" output generator
+│       ├── pipeline.py          # Orchestration of the full workflow
+│       ├── preprocess.py        # Text normalisation utilities
+│       └── prompt_library.py    # Prompt templates & keyword dictionaries
+└── tests
+    └── test_pipeline.py         # Automated regression tests
+```
+
+## Quickstart
+
+Create a virtual environment and install dependencies (only the standard
+library is used, so this step is optional):
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt  # optional: empty placeholder for future deps
+```
+
+Run the pipeline on the bundled sample data:
+
+```bash
+python -m pm_pipeline.cli --input data/sample_feedback.csv --output build
+```
+
+The command writes generated insights to the `build/` directory. Files include:
+
+- `product_brief.md`: top opportunities and customer promise.
+- `roadmap.md`: recommended roadmap themes and priority scores.
+- `summary.json`: structured export of aggregated metrics.
+
+## Testing
+
+Automated tests validate the core analytics logic:
+
+```bash
+pytest
+```
+
+## Extending With Real GenAI Services
+
+To plug in a live LLM provider, implement a drop-in replacement for
+`insight_generator.HeuristicInsightGenerator` that delegates the prompt
+construction to `prompt_library` and sends requests to the provider of your
+choice. The rest of the pipeline can remain unchanged.
+
+## License
+
+This project is released under the MIT License.

--- a/data/sample_feedback.csv
+++ b/data/sample_feedback.csv
@@ -1,0 +1,11 @@
+customer_id,segment,feedback,impact_rating,channel,timestamp
+C101,Enterprise,"We need better analytics dashboards; current charts take too long to load and don't show cohort trends.",High,Interview,2024-01-15
+C102,SMB,"Onboarding is confusing; a guided tour with AI tips would help new users ramp faster.",Medium,Survey,2024-01-20
+C103,Enterprise,"Billing exports fail when we have more than 5k invoices; need automation or bulk export.",High,Support Ticket,2024-02-03
+C104,Startup,"Love the automation rules but wish we had templates for marketing personas.",Medium,Community,2024-02-12
+C105,Enterprise,"Security review flagged missing audit logs for admin actions; deal blocker.",Critical,RFP,2024-02-19
+C106,SMB,"Mobile app notifications arrive too late for our team standups.",Low,Survey,2024-02-22
+C107,Enterprise,"Stakeholders asking for predictive insights; competitor already has AI-based forecasting.",High,Executive Brief,2024-03-01
+C108,Startup,"Our success manager mentioned workflow AI but there's no documentation on how to enable it.",Medium,Email,2024-03-08
+C109,SMB,"Integrations gallery is overwhelming; recommend AI-powered recommendation feed.",Medium,Interview,2024-03-15
+C110,Enterprise,"Need SOC2 compliant exports and automated anomaly detection for fraud monitoring.",Critical,Security Audit,2024-03-20

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+# This project currently uses only the Python standard library.
+# Add external dependencies here when integrating with real LLM services.

--- a/src/pm_pipeline/__init__.py
+++ b/src/pm_pipeline/__init__.py
@@ -1,0 +1,5 @@
+"""Product manager focused analytics pipeline."""
+
+from .pipeline import Pipeline, PipelineResult
+
+__all__ = ["Pipeline", "PipelineResult"]

--- a/src/pm_pipeline/analysis.py
+++ b/src/pm_pipeline/analysis.py
@@ -1,0 +1,73 @@
+"""Analytical helpers that surface trends for the pipeline."""
+
+from __future__ import annotations
+
+from collections import Counter, defaultdict
+from dataclasses import dataclass
+from statistics import mean
+from typing import Dict, Iterable, List, Mapping
+
+from .data_loader import FeedbackDataset, FeedbackRecord
+from .preprocess import normalise_text
+from .prompt_library import THEMES, Theme
+
+
+@dataclass
+class ThemeSignal:
+    theme: Theme
+    count: int
+    avg_impact: float
+    sample_feedback: List[FeedbackRecord]
+
+    @property
+    def priority_score(self) -> float:
+        return round(self.avg_impact * min(self.count, 5), 2)
+
+
+@dataclass
+class AnalysisResult:
+    total_records: int
+    segments: Mapping[str, int]
+    channels: Mapping[str, int]
+    theme_signals: List[ThemeSignal]
+
+
+def analyse(records: FeedbackDataset) -> AnalysisResult:
+    total_records = len(records)
+    segments = Counter(record.segment for record in records)
+    channels = Counter(record.channel for record in records)
+
+    theme_signals = _theme_signals(records)
+
+    return AnalysisResult(
+        total_records=total_records,
+        segments=segments,
+        channels=channels,
+        theme_signals=sorted(theme_signals, key=lambda s: s.priority_score, reverse=True),
+    )
+
+
+def _theme_signals(records: Iterable[FeedbackRecord]) -> List[ThemeSignal]:
+    theme_to_feedback: Dict[str, List[FeedbackRecord]] = defaultdict(list)
+    for record in records:
+        cleaned = normalise_text(record.feedback)
+        for theme_id, theme in THEMES.items():
+            if any(keyword in cleaned for keyword in theme.keywords):
+                theme_to_feedback[theme_id].append(record)
+
+    signals: List[ThemeSignal] = []
+    for theme_id, items in theme_to_feedback.items():
+        theme = THEMES[theme_id]
+        avg_impact = mean(record.impact_weight for record in items)
+        signals.append(
+            ThemeSignal(
+                theme=theme,
+                count=len(items),
+                avg_impact=round(avg_impact, 2),
+                sample_feedback=items[:3],
+            )
+        )
+    return signals
+
+
+__all__ = ["AnalysisResult", "ThemeSignal", "analyse"]

--- a/src/pm_pipeline/cli.py
+++ b/src/pm_pipeline/cli.py
@@ -1,0 +1,32 @@
+"""Command line interface for the product insights pipeline."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from .pipeline import Pipeline
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run the product insights pipeline")
+    parser.add_argument("--input", required=True, type=Path, help="Path to the feedback CSV file")
+    parser.add_argument(
+        "--output",
+        required=True,
+        type=Path,
+        help="Directory where generated artifacts will be stored",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    pipeline = Pipeline()
+    result = pipeline.run_from_csv(args.input)
+    Pipeline.write_outputs(result, args.output)
+    print(f"Generated artifacts in {args.output.resolve()}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/pm_pipeline/data_loader.py
+++ b/src/pm_pipeline/data_loader.py
@@ -1,0 +1,75 @@
+"""Utilities for loading product feedback data from CSV sources."""
+
+from __future__ import annotations
+
+import csv
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Iterable, List, Sequence
+
+
+@dataclass(frozen=True)
+class FeedbackRecord:
+    """Normalized representation of a single feedback entry."""
+
+    customer_id: str
+    segment: str
+    feedback: str
+    impact_rating: str
+    channel: str
+    timestamp: datetime
+
+    @property
+    def impact_weight(self) -> int:
+        """Map qualitative impact labels to numeric weights."""
+
+        mapping = {
+            "critical": 5,
+            "high": 4,
+            "medium": 3,
+            "low": 2,
+            "nice to have": 1,
+        }
+        return mapping.get(self.impact_rating.lower(), 2)
+
+
+class FeedbackDataset(List[FeedbackRecord]):
+    """Simple list-like container with helper constructors."""
+
+    @classmethod
+    def from_rows(cls, rows: Iterable[Sequence[str]]) -> "FeedbackDataset":
+        items: List[FeedbackRecord] = []
+        for row in rows:
+            timestamp = _parse_timestamp(row[5])
+            record = FeedbackRecord(
+                customer_id=row[0].strip(),
+                segment=row[1].strip(),
+                feedback=row[2].strip(),
+                impact_rating=row[3].strip(),
+                channel=row[4].strip(),
+                timestamp=timestamp,
+            )
+            items.append(record)
+        return cls(items)
+
+    @classmethod
+    def from_csv(cls, path: Path) -> "FeedbackDataset":
+        with path.open("r", newline="", encoding="utf-8") as handle:
+            reader = csv.reader(handle)
+            headers = next(reader, None)
+            if not headers:
+                raise ValueError("CSV file is empty")
+            return cls.from_rows(reader)
+
+
+def _parse_timestamp(raw: str) -> datetime:
+    for fmt in ("%Y-%m-%d", "%d/%m/%Y", "%Y/%m/%d"):
+        try:
+            return datetime.strptime(raw, fmt)
+        except ValueError:
+            continue
+    raise ValueError(f"Unsupported timestamp format: {raw}")
+
+
+__all__ = ["FeedbackRecord", "FeedbackDataset"]

--- a/src/pm_pipeline/insight_generator.py
+++ b/src/pm_pipeline/insight_generator.py
@@ -1,0 +1,120 @@
+"""Generate human-friendly insights from analysis results."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, List, Sequence
+
+from .analysis import AnalysisResult, ThemeSignal
+from .prompt_library import (
+    PRODUCT_BRIEF_TEMPLATE,
+    ROADMAP_TEMPLATE,
+    THEME_SECTION_TEMPLATE,
+)
+
+
+@dataclass
+class InsightArtifacts:
+    product_brief: str
+    roadmap: str
+    summary: dict
+
+
+class HeuristicInsightGenerator:
+    """Simple generator that approximates GenAI reasoning."""
+
+    def build_artifacts(self, analysis: AnalysisResult) -> InsightArtifacts:
+        brief = self._product_brief(analysis)
+        roadmap = self._roadmap(analysis.theme_signals)
+        summary = self._summary_payload(analysis)
+        return InsightArtifacts(product_brief=brief, roadmap=roadmap, summary=summary)
+
+    def _product_brief(self, analysis: AnalysisResult) -> str:
+        top_signal = analysis.theme_signals[0] if analysis.theme_signals else None
+        customer_promise = (
+            "Deliver a proactive intelligence platform that resolves high impact pain points"
+        )
+        if top_signal:
+            customer_promise = (
+                f"Deliver {top_signal.theme.name.lower()} so enterprise teams can {self._first_need(top_signal)}"
+            )
+        insights = self._insight_bullets(analysis.theme_signals)
+        evidence = self._evidence_summary(analysis)
+        stakeholders = "design, data science, and compliance"
+        return PRODUCT_BRIEF_TEMPLATE.format(
+            customer_promise=customer_promise,
+            insight_bullets=insights,
+            evidence_summary=evidence,
+            stakeholders=stakeholders,
+        )
+
+    def _insight_bullets(self, theme_signals: Sequence[ThemeSignal]) -> str:
+        lines = []
+        for signal in theme_signals[:3]:
+            sample = signal.sample_feedback[0].feedback if signal.sample_feedback else ""
+            lines.append(
+                f"- **{signal.theme.name}**: {sample} (signal strength {signal.priority_score}/5)"
+            )
+        if not lines:
+            lines.append("- Customer feedback volume is currently low; gather more inputs.")
+        return "\n".join(lines)
+
+    def _evidence_summary(self, analysis: AnalysisResult) -> str:
+        dominant_segment = max(analysis.segments, key=analysis.segments.get, default="all segments")
+        dominant_channel = max(analysis.channels, key=analysis.channels.get, default="mixed channels")
+        return f"{analysis.total_records} records across {dominant_segment} via {dominant_channel}"
+
+    def _first_need(self, signal: ThemeSignal) -> str:
+        if not signal.sample_feedback:
+            return "solve emergent needs"
+        return signal.sample_feedback[0].feedback.lower()
+
+    def _roadmap(self, theme_signals: Iterable[ThemeSignal]) -> str:
+        sections: List[str] = []
+        for signal in theme_signals:
+            sections.append(
+                THEME_SECTION_TEMPLATE.format(
+                    theme_name=signal.theme.name,
+                    why_now=self._why_now(signal),
+                    signal_strength=round(signal.priority_score, 1),
+                    first_experiment=self._experiment(signal),
+                )
+            )
+        if not sections:
+            sections.append("No roadmap items identified. Collect additional feedback.")
+        return ROADMAP_TEMPLATE.format(theme_sections="\n\n".join(sections))
+
+    def _why_now(self, signal: ThemeSignal) -> str:
+        if signal.avg_impact >= 4:
+            return "High impact enterprise accounts cite this as a blocker"
+        if signal.count > 3:
+            return "Volume of requests indicates a near-term retention risk"
+        return "Emerging opportunity to differentiate vs competitors"
+
+    def _experiment(self, signal: ThemeSignal) -> str:
+        if signal.theme.name.startswith("Trust"):
+            return "Partner with security to ship audit logging beta"
+        if signal.theme.name.startswith("Workflow"):
+            return "Launch AI guided onboarding pilot"
+        if signal.theme.name.startswith("Analytics"):
+            return "Prototype predictive forecasting dashboards"
+        return "Run performance benchmarking sprint"
+
+    def _summary_payload(self, analysis: AnalysisResult) -> dict:
+        return {
+            "total_records": analysis.total_records,
+            "segments": dict(analysis.segments),
+            "channels": dict(analysis.channels),
+            "themes": [
+                {
+                    "name": signal.theme.name,
+                    "count": signal.count,
+                    "avg_impact": signal.avg_impact,
+                    "priority_score": signal.priority_score,
+                }
+                for signal in analysis.theme_signals
+            ],
+        }
+
+
+__all__ = ["HeuristicInsightGenerator", "InsightArtifacts"]

--- a/src/pm_pipeline/pipeline.py
+++ b/src/pm_pipeline/pipeline.py
@@ -1,0 +1,49 @@
+"""High-level orchestration for the product insights pipeline."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+from .analysis import AnalysisResult, analyse
+from .data_loader import FeedbackDataset
+from .insight_generator import HeuristicInsightGenerator, InsightArtifacts
+from .preprocess import deduplicate
+
+
+@dataclass
+class PipelineResult:
+    analysis: AnalysisResult
+    artifacts: InsightArtifacts
+
+
+class Pipeline:
+    """Execute the end-to-end workflow from CSV to insight artifacts."""
+
+    def __init__(self, generator: Optional[HeuristicInsightGenerator] = None) -> None:
+        self._generator = generator or HeuristicInsightGenerator()
+
+    def run(self, dataset: FeedbackDataset) -> PipelineResult:
+        unique = deduplicate(dataset)
+        analysis = analyse(unique)
+        artifacts = self._generator.build_artifacts(analysis)
+        return PipelineResult(analysis=analysis, artifacts=artifacts)
+
+    def run_from_csv(self, path: Path) -> PipelineResult:
+        dataset = FeedbackDataset.from_csv(path)
+        return self.run(dataset)
+
+    @staticmethod
+    def write_outputs(result: PipelineResult, output_dir: Path) -> None:
+        output_dir.mkdir(parents=True, exist_ok=True)
+        (output_dir / "product_brief.md").write_text(result.artifacts.product_brief, encoding="utf-8")
+        (output_dir / "roadmap.md").write_text(result.artifacts.roadmap, encoding="utf-8")
+        (output_dir / "summary.json").write_text(
+            json.dumps(result.artifacts.summary, indent=2, default=str),
+            encoding="utf-8",
+        )
+
+
+__all__ = ["Pipeline", "PipelineResult"]

--- a/src/pm_pipeline/preprocess.py
+++ b/src/pm_pipeline/preprocess.py
@@ -1,0 +1,50 @@
+"""Text pre-processing utilities."""
+
+from __future__ import annotations
+
+import re
+from collections import Counter
+from typing import Iterable, List
+
+from .data_loader import FeedbackDataset, FeedbackRecord
+
+
+_SANITIZE_RE = re.compile(r"[^a-z0-9\s]")
+
+
+def normalise_text(text: str) -> str:
+    """Lowercase text and remove punctuation."""
+
+    lowered = text.lower().strip()
+    normalised = _SANITIZE_RE.sub("", lowered)
+    return re.sub(r"\s+", " ", normalised)
+
+
+def deduplicate(records: FeedbackDataset) -> FeedbackDataset:
+    """Remove duplicate feedback entries based on the cleaned text."""
+
+    seen = set()
+    unique: List[FeedbackRecord] = []
+    for record in records:
+        cleaned = normalise_text(record.feedback)
+        if cleaned in seen:
+            continue
+        seen.add(cleaned)
+        unique.append(record)
+    return FeedbackDataset(unique)
+
+
+def keyword_counts(records: Iterable[FeedbackRecord], keywords: Iterable[str]) -> Counter:
+    """Count keyword occurrences across all feedback entries."""
+
+    counts: Counter = Counter()
+    keyword_set = {normalise_text(word) for word in keywords}
+    for record in records:
+        cleaned = normalise_text(record.feedback)
+        for keyword in keyword_set:
+            if keyword in cleaned:
+                counts[keyword] += 1
+    return counts
+
+
+__all__ = ["normalise_text", "deduplicate", "keyword_counts"]

--- a/src/pm_pipeline/prompt_library.py
+++ b/src/pm_pipeline/prompt_library.py
@@ -1,0 +1,104 @@
+"""Prompt templates and semantic theme definitions."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, List
+
+
+@dataclass(frozen=True)
+class Theme:
+    """Represents a strategic product theme."""
+
+    name: str
+    description: str
+    keywords: List[str]
+
+
+THEMES: Dict[str, Theme] = {
+    "analytics": Theme(
+        name="Analytics Intelligence",
+        description="Advanced analytics, forecasting, and AI-driven insights",
+        keywords=[
+            "analytics",
+            "dashboard",
+            "forecast",
+            "predictive",
+            "insight",
+            "chart",
+            "cohort",
+        ],
+    ),
+    "automation": Theme(
+        name="Workflow Automation",
+        description="Automation templates, AI assistants, onboarding guidance",
+        keywords=[
+            "automation",
+            "workflow",
+            "guided",
+            "tour",
+            "template",
+            "ai",
+        ],
+    ),
+    "compliance": Theme(
+        name="Trust & Compliance",
+        description="Security, audit readiness, and enterprise governance",
+        keywords=[
+            "security",
+            "audit",
+            "soc2",
+            "compliance",
+            "fraud",
+            "log",
+        ],
+    ),
+    "scale": Theme(
+        name="Scalability",
+        description="Performance, exports, bulk workflows, and reliability",
+        keywords=[
+            "export",
+            "bulk",
+            "performance",
+            "scalability",
+            "load",
+            "latency",
+        ],
+    ),
+}
+
+
+PRODUCT_BRIEF_TEMPLATE = """# Product Opportunity Brief
+
+## Customer Promise
+{customer_promise}
+
+## High Impact Insights
+{insight_bullets}
+
+## Confidence & Next Steps
+- Confidence is boosted by {evidence_summary}.
+- Recommend engaging {stakeholders} to scope discovery workshops.
+"""
+
+
+ROADMAP_TEMPLATE = """# Roadmap Recommendations
+
+{theme_sections}
+"""
+
+
+THEME_SECTION_TEMPLATE = """## {theme_name}
+- Why now: {why_now}
+- Signal strength: {signal_strength}/5
+- First experiment: {first_experiment}
+"""
+
+
+__all__ = [
+    "Theme",
+    "THEMES",
+    "PRODUCT_BRIEF_TEMPLATE",
+    "ROADMAP_TEMPLATE",
+    "THEME_SECTION_TEMPLATE",
+]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,9 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import json
+from io import StringIO
+import csv
+from pathlib import Path
+
+from pm_pipeline.data_loader import FeedbackDataset
+from pm_pipeline.pipeline import Pipeline
+
+
+def build_dataset() -> FeedbackDataset:
+    csv_content = StringIO(
+        "customer_id,segment,feedback,impact_rating,channel,timestamp\n"
+        "C1,Enterprise,Need better analytics dashboards,High,Interview,2024-01-01\n"
+        "C2,Enterprise,Need better analytics dashboards,High,Interview,2024-01-02\n"
+        "C3,SMB,Executives request predictive analytics forecasts,High,Brief,2024-01-10\n"
+        "C4,SMB,Security audit reports missing,Critical,RFP,2024-02-10\n"
+        "C5,SMB,Automation templates would accelerate onboarding,Medium,Survey,2024-02-14\n"
+    )
+    csv_content.seek(0)
+    reader = csv.reader(csv_content)
+    next(reader)  # skip header
+    return FeedbackDataset.from_rows(reader)
+
+
+def test_pipeline_generates_artifacts(tmp_path: Path) -> None:
+    dataset = build_dataset()
+    pipeline = Pipeline()
+    result = pipeline.run(dataset)
+
+    assert result.analysis.total_records == 4  # duplicates removed
+    assert result.analysis.theme_signals[0].theme.name == "Analytics Intelligence"
+
+    output_dir = tmp_path / "outputs"
+    Pipeline.write_outputs(result, output_dir)
+
+    brief = (output_dir / "product_brief.md").read_text(encoding="utf-8")
+    roadmap = (output_dir / "roadmap.md").read_text(encoding="utf-8")
+    summary = json.loads((output_dir / "summary.json").read_text(encoding="utf-8"))
+
+    assert "Product Opportunity Brief" in brief
+    assert "Roadmap Recommendations" in roadmap
+    assert summary["total_records"] == 4
+    assert summary["themes"][0]["name"] == "Analytics Intelligence"


### PR DESCRIPTION
## Summary
- replace the placeholder repository contents with a runnable product insights pipeline for product managers
- add modular data ingestion, preprocessing, theme analysis, heuristic insight generation, and CLI orchestration packages
- document usage, ship a sample dataset, and cover the pipeline end-to-end with pytest automation

## Testing
- `PYTHONPATH=src pytest`


------
https://chatgpt.com/codex/tasks/task_e_68e6146f23e083308587c15e3e3806cd